### PR TITLE
searchresults.html

### DIFF
--- a/templates/searchresults.html
+++ b/templates/searchresults.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- CSS style for searchresults.html -->
+    <link rel="stylesheet" href="/static/dist/css/searchresults.css">
+</head>
+<body>
+    {% include 'header.html' %}
+    <main>
+        <!-- Search form for users to make another search -->
+        <form action="/searchresults" method="GET">
+            <input type="text" name="keyword" placeholder="Search for gigs...">
+            <select name="category" multiple size="5">
+                <!-- Categories options here -->
+                <option value="teaching">Teaching</option>
+                <option value="research">Research</option>
+                <option value="technical">Technical</option>
+                <option value="writing">Writing</option>
+                <option value="graphic_design">Graphic Design</option>
+                <option value="photography_film">Photography/Film</option>
+                <option value="events">Events</option>
+                <option value="marketing">Marketing</option>
+                <option value="administrative">Administrative</option>
+                <option value="volunteer">Volunteer</option>
+                <option value="fitness">Fitness</option>
+                <option value="other">Other</option>
+            </select>
+            <input type="submit" value="Search">
+        </form>
+        <!-- Use helper functions to fetch and display search results -->
+        <!-- 'gigs' is a list from Flask; {% for gig in gigs %} iterates over each gig. -->
+        <ul>
+            {% for gig in gigs %}
+                <li style="display: flex; justify-content: space-between; border-bottom: 1px solid #e0e0e0; padding: 10px;">
+                    <span>{{ gig.id }}</span>
+                    <span>|</span>
+                    <span>{{ gig.title }}</span>
+                    <span>|</span>
+                    <span>{{ gig.date_posted }}</span>
+                    <span>|</span>
+                    <span>{{ gig.start_date }}</span>
+                    <span>|</span>
+                    <span>{{ gig.end_date }}</span>
+                </li>
+            {% endfor %}
+        </ul>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
Integrated JINJA2-compatible for loop to display search results. When /searchresults route on the flask backend is invoked, it will use the get_gigs helper function to get the gigs, then those gigs will be passed as an argument as shown below. The gigs will pass into the html-integrated for loop and automatically display in a formatted way. 

@app.route('/searchresults')
def search_results():
    results = get_gigs() 
    return render_template('searchresults.html', results=results)